### PR TITLE
Added DisablePublicize, PublicizeOn and PublicizeOff attributes

### DIFF
--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -10,8 +10,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AssemblyToProcess</RootNamespace>
     <AssemblyName>AssemblyToProcess</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>3</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
@@ -45,18 +48,27 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="PublicDisabledClassWithEnabledMethod.cs" />
     <Compile Include="ClassWithNested.cs" />
     <Compile Include="InternalClass.cs" />
     <Compile Include="InternalInterface.cs" />
     <Compile Include="PrivateClass.cs" />
+    <Compile Include="PublicDisabledClass.cs" />
     <Compile Include="PublicClass.cs" />
     <Compile Include="PublicInterface.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Fody\Fody.csproj">
+      <Project>{c3578a7b-09a6-4444-9383-0deafa4958bd}</Project>
+      <Name>Fody</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/AssemblyToProcess/PublicDisabledClass.cs
+++ b/AssemblyToProcess/PublicDisabledClass.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Publicize.Fody.Attributes;
+
+[PublicizeOff]
+public class PublicDisabledClass
+{
+    private void TestMethod()
+    {
+        
+    }
+}

--- a/AssemblyToProcess/PublicDisabledClassWithEnabledMethod.cs
+++ b/AssemblyToProcess/PublicDisabledClassWithEnabledMethod.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Publicize.Fody.Attributes;
+
+[PublicizeOff]
+public class PublicDisabledClassWithEnabledMethod
+{
+    [PublicizeOn]
+    private void TestMethodToBePublic()
+    {
+
+    }
+
+    private void TestMethod2()
+    {
+
+    }
+}

--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -2,5 +2,5 @@
 
 [assembly: AssemblyTitle("Publicize")]
 [assembly: AssemblyProduct("Publicize")]
-[assembly: AssemblyVersion("1.3.6")]
-[assembly: AssemblyFileVersion("1.3.6")]
+[assembly: AssemblyVersion("1.4.0")]
+[assembly: AssemblyFileVersion("1.4.0")]

--- a/Fody/Attributes/DisablePublicizeAttribute.cs
+++ b/Fody/Attributes/DisablePublicizeAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Publicize.Fody.Attributes
+{
+    /// <summary>
+    /// Disables Publicize for the entire assembly.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public class DisablePublicizeAttribute: Attribute
+    {
+    }
+}

--- a/Fody/Attributes/PublicizeOffAttribute.cs
+++ b/Fody/Attributes/PublicizeOffAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Publicize.Fody.Attributes
+{ 
+    /// <summary>
+    /// Turns Publicize Off for this type/member and types below (cascading).
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Struct)]
+    public class PublicizeOffAttribute : Attribute
+    {
+    }
+}

--- a/Fody/Attributes/PublicizeOnAttribute.cs
+++ b/Fody/Attributes/PublicizeOnAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Publicize.Fody.Attributes
+{
+    /// <summary>
+    /// Turns Publicize On for this type/member and types below (cascading).
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Struct)]
+    public class PublicizeOnAttribute : Attribute
+    {
+    }
+}

--- a/Fody/Fody.csproj
+++ b/Fody/Fody.csproj
@@ -13,7 +13,6 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
-    
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -93,6 +92,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AttributeChecker.cs" />
+    <Compile Include="Attributes\DisablePublicizeAttribute.cs" />
+    <Compile Include="Attributes\PublicizeOffAttribute.cs" />
+    <Compile Include="Attributes\PublicizeOnAttribute.cs" />
     <Compile Include="IntegrationTests.cs" />
     <Compile Include="MsCoreReferenceFinder.cs" />
     <Compile Include="TypeProcessor.cs" />

--- a/Fody/IntegrationTests.cs
+++ b/Fody/IntegrationTests.cs
@@ -44,6 +44,25 @@ public class IntegrationTests
         Assert.IsTrue(type.ContainsHideAttribute());
         ValidateMembers(type);
     }
+
+    [Test]
+    public void PublicDisabledClass()
+    {
+        var type = assembly.CreateInstance("PublicDisabledClass").GetType();
+        Assert.IsFalse(type.ContainsHideAttribute());
+        var privateMethod = type.GetMethod("TestMethod");
+        Assert.IsNull(privateMethod);
+    }
+
+    [Test]
+    public void PublicDisabledClassWithEnabledMethod_FirstMethodIsPublicized()
+    {
+        var type = assembly.CreateInstance("PublicDisabledClassWithEnabledMethod").GetType();
+        var method = type.GetMethod("TestMethodToBePublic");
+        Assert.IsNotNull(method); // is public
+        Assert.IsTrue(method.ContainsHideAttribute());
+    }
+
     [Test]
     public void ContainsOnlyOneAttribute()
     {

--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Linq;
 using Mono.Cecil;
+using Mono.Collections.Generic;
+using Publicize.Fody.Attributes;
 
 public partial class ModuleWeaver
 {
@@ -14,11 +17,39 @@ public partial class ModuleWeaver
     public void Execute()
     {
         FindSystemTypes();
-
-        foreach (var type in ModuleDefinition.GetTypes())
+        // disables publicization for entire assembly
+        bool isPluginDisabled = ModuleDefinition.Assembly.CustomAttributes.Any(ca => ca.AttributeType.Name == typeof(DisablePublicizeAttribute).Name);
+        if (!isPluginDisabled)
         {
-            ProcessType(type);
+            // get assembly level Publicize state (On or Off)
+            bool isEnabled = IsPublicizeEnabled(ModuleDefinition.Assembly.CustomAttributes, true);
+
+            foreach (var type in ModuleDefinition.GetTypes())
+            {
+                ProcessType(type, isEnabled);
+            }
         }
     }
 
+    /// <summary>
+    /// Retrieves publicization enable state for a type/member
+    /// </summary>
+    /// <param name="source"></param>
+    /// <param name="defaultValue"></param>
+    /// <returns></returns>
+    public bool IsPublicizeEnabled(Collection<CustomAttribute> source, bool defaultValue)
+    {
+        foreach (CustomAttribute attrib in source)
+        {
+            if (attrib.AttributeType.Name == typeof(PublicizeOnAttribute).Name)
+            {
+                return true;
+            }
+            else if (attrib.AttributeType.Name == typeof(PublicizeOffAttribute).Name)
+            {
+                return false;
+            }
+        }
+        return defaultValue;
+    }
 }


### PR DESCRIPTION
Bumped version to 1.4 as well.
One thing missing is that the project using this plugin would need to reference it (to be able to use the new attributes).
PublicizeOn and Off are cascading style attributes. They affect current type/member and below unless there is another On or Off down the tree.
DisablePublicize is an assembly level attribute which disables publicize entirely. Useful for i.e. Release configuration if one doesn't want Publicize to run at all.
